### PR TITLE
#230 - always check mouse event

### DIFF
--- a/src/components/Input.ts
+++ b/src/components/Input.ts
@@ -621,9 +621,10 @@ module Kiwi.Components {
 			// Use the appropriate method of checking.
 			if ( Kiwi.DEVICE.touch ) {
 				this._updateTouch();
-			} else {
-				this._updateMouse();
 			}
+			// Always check mouse. E.g. Windows 10 with touch display can fire touch and mouse event.
+			this._updateMouse();
+			
 
 			// If the entity is dragging.
 			if ( this.isDragging ) {


### PR DESCRIPTION
Fix of issue #230. The problem was that touch events blocked firing mouse events.
In case of touch and mouse events present on device, the mouse was not working.
